### PR TITLE
- Update clean run history logic

### DIFF
--- a/tasks/cpm_clean.yml
+++ b/tasks/cpm_clean.yml
@@ -30,11 +30,26 @@
     path: "{{ cpm_extract_folder }}"
     state: absent
 
-- name: clean run history
-  win_regedit:
-    path: 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU'
-    state: absent
-    delete_key: yes
+- name: Clean Run History
+  win_shell: |
+    try {
+      $path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\RunMRU"
+
+      if (& { Test-Path $path } 2>&1) {
+        $arr = (Get-Item -Path $path).Property
+        foreach ($item in $arr)
+        {
+          if ($item -ne "(Default)")
+          {
+            Remove-ItemProperty -Path $path -Name $item -ErrorAction SilentlyContinue
+          }
+        }
+      }
+    } catch {
+      Write-Output "Error occured: $error"
+      exit 1
+    }
+    exit 0
 
 - name: clean event logs
   win_shell: |


### PR DESCRIPTION
Cleaning the Run history should leave the default key, therefore there is a powershell to handle that instead of deleting the whole key.